### PR TITLE
Refactor Unit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.un~
 pkg/
 
+.vscode
+
 # Berkshelf
 .vagrant
 /cookbooks

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'berkshelf', '~> 4.3'
 gem 'chef', '~> 12.4'
-gem 'compat_resource', '~> 12.5', '>= 12.5.6'
 gem 'rubocop', '~> 0.41'
 gem 'foodcritic', '~> 6.0'
 gem 'chefspec', '~> 5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'chef', '~> 12.4'
 gem 'compat_resource', '~> 12.5', '>= 12.5.6'
 gem 'rubocop', '~> 0.41'
 gem 'foodcritic', '~> 6.0'
-gem 'chefspec', '~> 4.7'
+gem 'chefspec', '~> 5.0'
 
 group :local do
   gem 'test-kitchen', '~> 1.10'

--- a/spec/unit/resources/install_examples.rb
+++ b/spec/unit/resources/install_examples.rb
@@ -1,5 +1,6 @@
 shared_examples 'should install' do |platform, expected_url|
   it { is_expected.to create_remote_file(package_path).with(source: expected_url) }
+  it { is_expected.to run_ruby_block('load_version_state') }
 
   case platform
   when 'redhat' then it { is_expected.to install_rpm_package(package_name).with(source: package_path) }

--- a/spec/unit/resources/install_examples.rb
+++ b/spec/unit/resources/install_examples.rb
@@ -1,64 +1,22 @@
 shared_examples 'should install' do |platform, expected_url|
-  it 'should install' do
-    expect(chef_run).to create_remote_file(package_path).with(source: expected_url)
+  it { is_expected.to create_remote_file(package_path).with(source: expected_url) }
 
-    case platform
-    when 'redhat' then expect(chef_run).to install_rpm_package(package_name).with(source: package_path)
-    when 'ubuntu' then expect(chef_run).to install_dpkg_package(package_name).with(source: package_path)
-    when 'windows' then expect(chef_run).to install_windows_package(package_name).with(options: windows_opts)
-    else expect(chef_run).to extract_local_tar_extract(package_path).with(target_dir: install_dir)
-    end
+  case platform
+  when 'redhat' then it { is_expected.to install_rpm_package(package_name).with(source: package_path) }
+  when 'ubuntu' then it { is_expected.to install_dpkg_package(package_name).with(source: package_path) }
+  when 'windows' then it { is_expected.to install_windows_package(package_name).with(options: windows_opts) }
+  else it { is_expected.to extract_local_tar_extract(package_path).with(target_dir: install_dir) }
   end
 end
 
-shared_examples 'should not install' do |platform, expected_url|
-  it 'should not install' do
-    expect(chef_run).not_to create_remote_file(package_path).with(source: expected_url)
-
-    case platform
-    when 'redhat' then expect(chef_run).not_to install_rpm_package(package_name)
-    when 'ubuntu' then expect(chef_run).not_to install_dpkg_package(package_name)
-    when 'windows' then expect(chef_run).not_to install_windows_package(package_name)
-    else expect(chef_run).not_to extract_local_tar_extract(package_path)
-    end
-  end
-end
-
-shared_examples 'should uninstall' do |platform, package|
-  it 'should uninstall' do
-    case platform
-    when 'redhat' then expect(chef_run).to remove_rpm_package(package_name)
-    when 'ubuntu' then expect(chef_run).to purge_dpkg_package(package_name)
-    when 'windows' then expect(chef_run).to remove_windows_package(package_name)
-    else expect(chef_run).to delete_directory(install_dir).with(recursive: true)
-    end
-
-    command_prefix = runner_params[:platform] == 'windows' ? 'splunk.exe' : './splunk'
-
-    expect(chef_run).to stop_splunk_service(package)
-    expect(chef_run).to run_execute("#{command_prefix} disable boot-start").with(cwd: "#{install_dir}/bin")
-
-    expect(run_state).not_to include(:current_installation)
-    expect(run_state['installations']).not_to include(install_dir)
-  end
-end
-
-shared_context 'test setup' do |platform, version, package|
-  let(:package_name) { package_names[package][runner_params[:platform] == 'windows' ? :windows : :linux] }
-  let(:install_dir) { default_install_dirs[package][runner_params[:platform] == 'windows' ? :windows : :linux] }
-  let(:runner_params) { { platform: platform, version: version } }
-end
-
-shared_examples 'standard install' do |platform, version, package, expected_url|
-  context "with the '#{package}' package" do
-    include_context 'test setup', platform, version, package
-    let(:package) { package }
+shared_examples 'standard install' do |platform, package, expected_url|
+  chef_context "with the '#{package}' package" do
     let(:test_params) { { name: package.to_s, build: 'cae2458f4aef', version: '6.3.4' } }
     let(:package_path) { "./test/unit/.cache/#{filename_from_url(expected_url)}" }
 
     include_examples 'should install', platform, expected_url
 
-    context 'when already installed' do
+    chef_context 'when already installed' do
       let(:install) do
         {
           name: package.to_s,
@@ -78,7 +36,8 @@ shared_examples 'standard install' do |platform, version, package, expected_url|
           }
         }
       end
-      context 'with a different version' do
+
+      chef_context 'with a different version' do
         let(:install) do
           {
             name: package.to_s,
@@ -92,16 +51,22 @@ shared_examples 'standard install' do |platform, version, package, expected_url|
         include_examples 'should install', platform, expected_url
       end
 
-      context 'with the same version' do
-        include_examples 'should not install', platform, expected_url
+      chef_context 'with the same version' do
+        it { is_expected.not_to create_remote_file(package_path).with(source: expected_url) }
+
+        case platform
+        when 'redhat' then it { is_expected.not_to install_rpm_package(package_name) }
+        when 'ubuntu' then it { is_expected.not_to install_dpkg_package(package_name) }
+        when 'windows' then it { is_expected.not_to install_windows_package(package_name) }
+        else it { is_expected.not_to extract_local_tar_extract(package_path) }
+        end
       end
     end
   end
 end
 
-shared_examples 'standard uninstall' do |platform, version, package|
-  context "with the '#{package}' package" do
-    include_context 'test setup', platform, version, package
+shared_examples 'standard uninstall' do |platform, package|
+  chef_context "with the '#{package}' package" do
     let(:test_params) { { name: package.to_s, action: :uninstall } }
     let(:mock_run_state) do
       install = {
@@ -121,6 +86,19 @@ shared_examples 'standard uninstall' do |platform, version, package|
       }
     end
 
-    include_examples 'should uninstall', platform, package
+    case platform
+    when 'redhat' then it { is_expected.to remove_rpm_package(package_name) }
+    when 'ubuntu' then it { is_expected.to purge_dpkg_package(package_name) }
+    when 'windows' then it { is_expected.to remove_windows_package(package_name) }
+    else it { is_expected.to delete_directory(install_dir).with(recursive: true) }
+    end
+
+    it { is_expected.to stop_splunk_service(package) }
+    it { is_expected.to run_execute("#{command_prefix} disable boot-start").with(cwd: "#{install_dir}/bin") }
+
+    it 'should remove run state' do
+      expect(run_state).not_to include(:current_installation)
+      expect(run_state['installations']).not_to include(install_dir)
+    end
   end
 end

--- a/spec/unit/resources/splunk_conf_spec.rb
+++ b/spec/unit/resources/splunk_conf_spec.rb
@@ -3,7 +3,7 @@ include CernerSplunk::ConfHelpers, CernerSplunk::ResourceHelpers
 
 shared_examples 'splunk_conf' do |platform, version, package|
   let(:runner_params) { { platform: platform, version: version, user: 'root' } }
-  chef_context 'action :configure' do
+  chef_describe 'action :configure' do
     let(:config) { { a: { 'foo' => 'bar', 'one' => 1 } } }
     let(:existing_config) { { 'a' => { 'foo' => 'bar' } } }
     let(:expected_state_config) { { 'a' => { 'foo' => 'bar', 'one' => 1 } } }
@@ -209,8 +209,8 @@ describe 'splunk_conf' do
   let(:test_recipe) { 'config_unit_test' }
 
   environment_combinations.each do |platform, version, package, _|
-    describe "on #{platform} #{version}" do
-      describe "with package #{package}" do
+    context "on #{platform} #{version}" do
+      context "with package #{package}" do
         include_examples 'splunk_conf', platform, version, package
       end
     end

--- a/spec/unit/resources/splunk_conf_spec.rb
+++ b/spec/unit/resources/splunk_conf_spec.rb
@@ -1,6 +1,4 @@
-
 require_relative '../spec_helper'
-
 include CernerSplunk::ConfHelpers, CernerSplunk::ResourceHelpers
 
 shared_examples 'splunk_conf' do |platform, version, package|
@@ -207,8 +205,6 @@ shared_examples 'splunk_conf' do |platform, version, package|
 end
 
 describe 'splunk_conf' do
-  include CernerSplunk::PathHelpers
-
   let(:test_resource) { 'splunk_conf' }
   let(:test_recipe) { 'config_unit_test' }
 

--- a/spec/unit/resources/splunk_conf_spec.rb
+++ b/spec/unit/resources/splunk_conf_spec.rb
@@ -4,8 +4,8 @@ require_relative '../spec_helper'
 include CernerSplunk::ConfHelpers, CernerSplunk::ResourceHelpers
 
 shared_examples 'splunk_conf' do |platform, version, package|
-  describe 'action :configure' do
-    let(:runner_params) { { platform: platform, version: version, user: 'root' } }
+  let(:runner_params) { { platform: platform, version: version, user: 'root' } }
+  chef_context 'action :configure' do
     let(:config) { { a: { 'foo' => 'bar', 'one' => 1 } } }
     let(:existing_config) { { 'a' => { 'foo' => 'bar' } } }
     let(:expected_state_config) { { 'a' => { 'foo' => 'bar', 'one' => 1 } } }
@@ -40,8 +40,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
 
     let(:conf_path) { Pathname.new(install_dir) + 'etc/system/local/test.conf' }
 
-    context 'when all parameters provided' do
-      let(:conf_path) { Pathname.new(install_dir) + 'etc/system/default/test.conf' }
+    chef_context 'when all parameters provided' do
       let(:test_params) do
         {
           path: 'system/test.conf',
@@ -53,6 +52,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
         }
       end
 
+      let(:conf_path) { Pathname.new(install_dir) + 'etc/system/default/test.conf' }
       let(:expected_params) do
         {
           path: conf_path,
@@ -68,7 +68,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
       it { is_expected.to init_splunk_service('init_before_config') }
     end
 
-    context 'when scope is not provided' do
+    chef_context 'when scope is not provided' do
       let(:test_params) do
         {
           path: 'system/local/test.conf',
@@ -81,7 +81,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
 
       it { is_expected.to configure_splunk('system/local/test.conf') }
 
-      context 'when the path does not include scope' do
+      chef_context 'when the path does not include scope' do
         let(:test_params) do
           {
             path: 'system/test.conf',
@@ -96,7 +96,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
       end
     end
 
-    context 'when package is not provided' do
+    chef_context 'when package is not provided' do
       let(:test_params) do
         {
           path: 'system/test.conf',
@@ -109,7 +109,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
 
       it { is_expected.to configure_splunk('system/test.conf') }
 
-      context 'without a prior install' do
+      chef_context 'without a prior install' do
         let(:chef_run_stubs) {}
         let(:mock_run_state) do
           install = {
@@ -129,12 +129,12 @@ shared_examples 'splunk_conf' do |platform, version, package|
         end
 
         it 'should fail the chef run' do
-          expect { chef_run }.to raise_error Chef::Exceptions::ValidationFailed, /package is required$/
+          expect { subject }.to raise_error Chef::Exceptions::ValidationFailed, /package is required$/
         end
       end
     end
 
-    context 'when config is not provided' do
+    chef_context 'when config is not provided' do
       let(:test_params) do
         {
           path: 'system/test.conf',
@@ -146,10 +146,10 @@ shared_examples 'splunk_conf' do |platform, version, package|
       let(:chef_run_stubs) {}
 
       it 'should fail the chef run' do
-        expect { chef_run }.to raise_error Chef::Exceptions::ValidationFailed, /config is required$/
+        expect { subject }.to raise_error Chef::Exceptions::ValidationFailed, /config is required$/
       end
 
-      context 'when reset is specified' do
+      chef_context 'when reset is specified' do
         let(:test_params) do
           {
             path: 'system/test.conf',
@@ -161,12 +161,12 @@ shared_examples 'splunk_conf' do |platform, version, package|
         end
 
         it 'should fail the chef run' do
-          expect { chef_run }.to raise_error Chef::Exceptions::ValidationFailed, /config is required$/
+          expect { subject }.to raise_error Chef::Exceptions::ValidationFailed, /config is required$/
         end
       end
     end
 
-    context 'when user is not specified' do
+    chef_context 'when user is not specified' do
       let(:test_params) do
         {
           path: 'system/test.conf',
@@ -181,7 +181,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
       it { is_expected.to create_file(conf_path).with(content: 'merged config', owner: platform == 'windows' ? nil : 'fauxhai') }
     end
 
-    context 'when reset is specified' do
+    chef_context 'when reset is specified' do
       let(:test_params) do
         {
           path: 'system/test.conf',
@@ -209,20 +209,8 @@ end
 describe 'splunk_conf' do
   include CernerSplunk::PathHelpers
 
-  let(:mock_run_state) { { 'splunk_ingredient' => { 'installations' => {} } } }
-  let(:chef_run_stubs) {}
-
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new({ step_into: ['splunk_conf'] }.merge!(runner_params)) do |node|
-      node.normal['test_parameters'] = test_params
-      node.normal['run_state'].merge!(mock_run_state)
-      chef_run_stubs
-    end.converge('cerner_splunk_ingredient_test::config_unit_test')
-  end
-
-  let(:run_state) { chef_run.node.run_state['splunk_ingredient'] }
-
-  subject { chef_run }
+  let(:test_resource) { 'splunk_conf' }
+  let(:test_recipe) { 'config_unit_test' }
 
   environment_combinations.each do |platform, version, package, _|
     describe "on #{platform} #{version}" do

--- a/spec/unit/resources/splunk_install_spec.rb
+++ b/spec/unit/resources/splunk_install_spec.rb
@@ -21,7 +21,6 @@ describe 'splunk_install' do
         let(:command_prefix) { runner_params[:platform] == 'windows' ? 'splunk.exe' : './splunk' }
 
         let(:common_stubs) do
-          allow_any_instance_of(Chef::Provider).to receive(:load_version_state)
           allow_any_instance_of(Chef::Resource).to receive(:current_owner).and_return('fauxhai')
         end
 

--- a/spec/unit/resources/splunk_install_spec.rb
+++ b/spec/unit/resources/splunk_install_spec.rb
@@ -4,120 +4,120 @@ require_relative 'install_examples'
 describe 'splunk_install' do
   include CernerSplunk::PathHelpers, CernerSplunk::PlatformHelpers
 
-  let(:runner_params) { { platform: 'redhat', version: '7.1' } }
-  let(:test_params) { { name: 'splunk', build: 'cae2458f4aef', version: '6.3.4' } }
+  let(:test_resource) { 'splunk_install' }
+  let(:test_recipe) { 'install_unit_test' }
 
-  let(:windows_opts) { 'LAUNCHSPLUNK=0 INSTALL_SHORTCUT=0 AGREETOLICENSE=Yes' }
+  environment_combinations.each do |platform, version, package, expected_url|
+    describe "on #{platform} #{version}" do
+      describe "with package #{package}" do
+        let(:runner_params) { { platform: platform, version: version, user: 'root' } }
 
-  let(:mock_run_state) { { 'splunk_ingredient' => { 'installations' => {} } } }
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new({ step_into: ['splunk_install'] }.merge!(runner_params)) do |node|
-      node.normal['test_parameters'] = test_params
-      node.normal['run_state'].merge!(mock_run_state)
-    end.converge('cerner_splunk_ingredient_test::install_unit_test')
-  end
+        let(:test_params) { { name: 'splunk', build: 'cae2458f4aef', version: '6.3.4' } }
+        let(:mock_run_state) { { 'splunk_ingredient' => { 'installations' => {} } } }
 
-  before do
-    allow_any_instance_of(Chef::Resource).to receive(:current_owner).and_return('fauxhai')
-  end
+        let(:package_name) { package_names[package][runner_params[:platform] == 'windows' ? :windows : :linux] }
+        let(:install_dir) { default_install_dirs[package][runner_params[:platform] == 'windows' ? :windows : :linux] }
+        let(:windows_opts) { 'LAUNCHSPLUNK=0 INSTALL_SHORTCUT=0 AGREETOLICENSE=Yes' }
+        let(:command_prefix) { runner_params[:platform] == 'windows' ? 'splunk.exe' : './splunk' }
 
-  let(:run_state) { chef_run.node.run_state['splunk_ingredient'] }
+        let(:common_stubs) do
+          allow_any_instance_of(Chef::Provider).to receive(:load_version_state)
+          allow_any_instance_of(Chef::Resource).to receive(:current_owner).and_return('fauxhai')
+        end
 
-  describe 'action :install' do
-    before do
-      allow_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return false
-      allow_any_instance_of(Chef::Provider).to receive(:load_version_state)
-    end
-    platform_package_matrix.each do |platform, versions|
-      versions.each do |version, packages|
-        describe "on #{platform} #{version}" do
-          packages.each do |package, expected_url|
-            include_examples 'standard install', platform, version, package, expected_url
+        let(:chef_run_stubs) do
+          common_stubs
+          action_stubs
+        end
+
+        chef_context 'action :install' do
+          let(:action_stubs) do
+            allow_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return false
+          end
+
+          include_examples 'standard install', platform, package, expected_url
+
+          if [platform, package] == ['redhat', :universal_forwarder]
+            chef_context 'with a non-package name' do
+              let(:test_params) do
+                {
+                  name: 'Logmaster',
+                  package: :universal_forwarder,
+                  build: 'cae2458f4aef',
+                  version: '6.3.4'
+                }
+              end
+
+              it { is_expected.to install_rpm_package('splunkforwarder') }
+            end
+
+            chef_context 'with base_url' do
+              let(:test_params) do
+                {
+                  package: :universal_forwarder,
+                  build: 'cae2458f4aef',
+                  version: '6.3.4',
+                  base_url: 'https://repo.internet.website/splunk'
+                }
+              end
+              let(:base_expected_url) do
+                'https://repo.internet.website/splunk/universalforwarder/releases/6.3.4/linux/splunkforwarder-6.3.4-cae2458f4aef-linux-2.6-x86_64.rpm'
+              end
+              let(:package_path) { "./test/unit/.cache/#{filename_from_url(expected_url)}" }
+
+              it { is_expected.to create_remote_file(package_path).with(source: base_expected_url) }
+            end
+          end
+
+          chef_context 'when package is not specified' do
+            let(:test_params) { { name: 'hotcakes', build: 'cae2458f4aef', version: '6.3.4' } }
+
+            it 'should fail the Chef run' do
+              expect { subject }.to raise_error(RuntimeError, /Package must be specified.*/)
+            end
+          end
+
+          chef_context 'when version is not specified' do
+            let(:test_params) { { build: 'cae2458f4aef' } }
+
+            it 'should fail the Chef run' do
+              expect { subject }.to raise_error(Chef::Exceptions::ValidationFailed, /.* version is required/)
+            end
+          end
+
+          chef_context 'when build is not specified' do
+            let(:test_params) { { version: '6.3.4' } }
+
+            it 'should fail the Chef run' do
+              expect { subject }.to raise_error(Chef::Exceptions::ValidationFailed, /.* build is required/)
+            end
+          end
+
+          chef_context 'when platform is not supported' do
+            let(:runner_params) { { platform: 'aix', version: '7.1' } }
+            let(:test_params) { { name: 'splunk', build: 'cae2458f4aef', version: '6.3.4' } }
+
+            it 'should fail the Chef run' do
+              expect { subject }.to raise_error(RuntimeError, /Unsupported Combination.*/)
+            end
           end
         end
-      end
-    end
 
-    context 'with a non-package name' do
-      let(:test_params) { { name: 'Logmaster', package: :universal_forwarder, build: 'cae2458f4aef', version: '6.3.4' } }
+        chef_context 'action :uninstall' do
+          let(:action_stubs) do
+            allow_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return true
+          end
 
-      it 'should install' do
-        expect(chef_run).to install_rpm_package('splunkforwarder')
-      end
-    end
+          include_examples 'standard uninstall', platform, package
 
-    context 'with base_url' do
-      let(:expected_url) do
-        'https://repo.internet.website/splunk/universalforwarder/releases/6.3.4/linux/splunkforwarder-6.3.4-cae2458f4aef-linux-2.6-x86_64.rpm'
-      end
-      let(:package_path) { "./test/unit/.cache/#{filename_from_url(expected_url)}" }
-      let(:test_params) do
-        {
-          package: :universal_forwarder,
-          build: 'cae2458f4aef',
-          version: '6.3.4',
-          base_url: 'https://repo.internet.website/splunk'
-        }
-      end
+          chef_context 'when package is not specified' do
+            let(:test_params) { { name: 'hotcakes', action: :uninstall } }
 
-      it 'should download the package' do
-        expect(chef_run).to create_remote_file(package_path).with(source: expected_url)
-      end
-    end
-
-    context 'when package is not specified' do
-      let(:test_params) { { name: 'hotcakes', build: 'cae2458f4aef', version: '6.3.4' } }
-
-      it 'should fail the Chef run' do
-        expect { chef_run }.to raise_error(RuntimeError, /Package must be specified.*/)
-      end
-    end
-
-    context 'when version is not specified' do
-      let(:test_params) { { build: 'cae2458f4aef' } }
-
-      it 'should fail the Chef run' do
-        expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed, /.* version is required/)
-      end
-    end
-
-    context 'when build is not specified' do
-      let(:test_params) { { version: '6.3.4' } }
-
-      it 'should fail the Chef run' do
-        expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed, /.* build is required/)
-      end
-    end
-
-    context 'when platform is not supported' do
-      let(:runner_params) { { platform: 'aix', version: '7.1' } }
-      let(:test_params) { { name: 'splunk', build: 'cae2458f4aef', version: '6.3.4' } }
-
-      it 'should fail the Chef run' do
-        expect { chef_run }.to raise_error(RuntimeError, /Unsupported Combination.*/)
-      end
-    end
-  end
-
-  describe 'action :uninstall' do
-    before do
-      allow_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return true
-      allow_any_instance_of(Chef::Provider).to receive(:load_version_state)
-    end
-    platform_package_matrix.each do |platform, versions|
-      versions.each do |version, packages|
-        context "on #{platform} #{version}" do
-          packages.each do |package, _|
-            include_examples 'standard uninstall', platform, version, package
+            it 'should fail the Chef run' do
+              expect { subject }.to raise_error(RuntimeError, /Package must be specified.*/)
+            end
           end
         end
-      end
-    end
-
-    context 'when package is not specified' do
-      let(:test_params) { { name: 'hotcakes', action: :uninstall } }
-      it 'should fail the Chef run' do
-        expect { chef_run }.to raise_error(RuntimeError, /Package must be specified.*/)
       end
     end
   end

--- a/spec/unit/resources/splunk_install_spec.rb
+++ b/spec/unit/resources/splunk_install_spec.rb
@@ -8,8 +8,8 @@ describe 'splunk_install' do
   let(:test_recipe) { 'install_unit_test' }
 
   environment_combinations.each do |platform, version, package, expected_url|
-    describe "on #{platform} #{version}" do
-      describe "with package #{package}" do
+    context "on #{platform} #{version}" do
+      context "with package #{package}" do
         let(:runner_params) { { platform: platform, version: version, user: 'root' } }
 
         let(:test_params) { { name: 'splunk', build: 'cae2458f4aef', version: '6.3.4' } }
@@ -29,7 +29,7 @@ describe 'splunk_install' do
           action_stubs
         end
 
-        chef_context 'action :install' do
+        chef_describe 'action :install' do
           let(:action_stubs) do
             allow_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return false
           end
@@ -102,7 +102,7 @@ describe 'splunk_install' do
           end
         end
 
-        chef_context 'action :uninstall' do
+        chef_describe 'action :uninstall' do
           let(:action_stubs) do
             allow_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return true
           end

--- a/spec/unit/resources/splunk_service_spec.rb
+++ b/spec/unit/resources/splunk_service_spec.rb
@@ -1,137 +1,146 @@
 require_relative '../spec_helper'
 
-# TODO: Change how we're stubbing methods during refactoring so we can move this out of the global object space.
 include CernerSplunk::ServiceHelpers, CernerSplunk::RestartHelpers
 
-describe 'splunk_service' do
-  let(:runner_params) { { platform: 'redhat', version: '7.1' } }
-  let(:test_params) { { name: 'splunk', action: :nothing } }
-
-  let(:mock_run_state) { { 'splunk_ingredient' => { 'installations' => {} } } }
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new({ step_into: ['splunk_service'] }.merge!(runner_params)) do |node|
-      node.normal['test_parameters'] = test_params
-      node.normal['run_state'].merge!(mock_run_state)
-    end.converge('cerner_splunk_ingredient_test::service_unit_test')
+shared_examples '*start examples' do |action, platform, _, package|
+  is_windows = platform == 'windows'
+  let(:action_stubs) do
+    expect_any_instance_of(Chef::Provider).not_to receive(:write_initd_ulimit)
+    expect_any_instance_of(Chef::Provider).not_to receive(:ensure_restart)
   end
 
-  let(:ftr) { double('ftr_pathname') }
-  let(:init_script) { double('init_script_path') }
+  case action
+  when :start
+    it { is_expected.to start_service(service_name) }
+  when :restart
+    it { is_expected.to restart_service(service_name) }
+  end
 
-  let(:run_state) { chef_run.node.run_state['splunk_ingredient'] }
+  chef_context 'when the service has not been run for the first time' do
+    let(:ftr_exists) { true }
+    let(:action_stubs) do
+      expect_any_instance_of(Chef::Provider).not_to receive(:write_initd_ulimit)
+      expect_any_instance_of(Chef::Provider).not_to receive(:ensure_restart)
+    end
 
-  %w(start stop restart).each do |action|
-    describe "with action :#{action}" do
-      platform_package_matrix.select { |k, _| %w(windows redhat).include? k }.each do |platform, versions|
-        versions.each do |version, packages|
-          describe "on #{platform} #{version}" do
-            packages.each do |package, _|
-              context "with #{package}" do
-                let(:runner_params) { { platform: platform, version: version, user: 'root' } }
-                let(:test_params) { { name: package.to_s, action: action.to_sym } }
-                let(:running) { false }
-                is_windows = platform == 'windows'
-                let(:service_name) do
-                  if is_windows
-                    package == :splunk ? 'splunkd' : 'splunkforwarder'
-                  else
-                    'splunk'
-                  end
-                end
+    case action
+    when :start
+      it { is_expected.to start_service(service_name) }
+    when :restart
+      it { is_expected.to restart_service(service_name) }
+    end
+  end
 
-                before do
-                  allow_any_instance_of(Chef::Resource).to receive(:current_owner).and_return(is_windows ? nil : 'fauxhai')
+  unless is_windows
+    chef_context 'when the ulimit is specified' do
+      let!(:original_stubs) { action_stubs }
 
-                  allow_any_instance_of(Chef::Provider).to receive(:ftr_pathname).and_return ftr
-                  allow(ftr).to receive(:exist?).and_return !running
+      let(:test_params) { { name: package.to_s, action: action, ulimit: 4096 } }
+      let(:action_stubs) do
+        expect_any_instance_of(Chef::Provider).to receive(:service_running).and_return(nil) if action == :start
+        expect_any_instance_of(Chef::Provider).to receive(:write_initd_ulimit).with(4096)
+        expect_any_instance_of(Chef::Provider).not_to receive(:ensure_restart)
+      end
 
-                  expect_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return true
-                  expect_any_instance_of(Chef::Resource).to receive(:check_restart)
-                  allow_any_instance_of(Chef::Resource).to receive(:service_running).and_return(nil) unless is_windows
+      it 'should set the ulimit' do
+        subject
+      end
 
-                  allow(init_script).to receive(:exist?).and_return(false)
-                  allow_any_instance_of(Chef::Resource).to receive(:init_script_path).and_return(init_script)
+      chef_context 'when the service is running' do
+        let(:action_stubs) do
+          expect_any_instance_of(Chef::Provider).to receive(:service_running).at_least(:once).and_return(true)
+          expect_any_instance_of(Chef::Provider).to receive(:write_initd_ulimit).with(4096)
+          expect_any_instance_of(Chef::Provider).to receive(:ensure_restart)
+        end
 
-                  expect_any_instance_of(Chef::Provider).to receive(:clear_restart) if action == 'restart'
-                end
+        it 'should ensure a service restart' do
+          subject
+        end
+      end if action == :start
 
-                let(:cmd_prefix) { is_windows ? 'splunk.exe' : './splunk' }
+      chef_context 'when the ulimit is the same' do
+        let(:test_params) { { name: package.to_s, action: action, ulimit: 1024 } }
+        let(:init_script_exists) { true }
+        let(:action_stubs) do
+          expect(init_script).to receive(:read).and_return(IO.read('spec/reference/splunk_initd'))
+          expect_any_instance_of(Chef::Provider).not_to receive(:service_running)
+          expect_any_instance_of(Chef::Provider).not_to receive(:write_initd_ulimit)
+          expect_any_instance_of(Chef::Provider).not_to receive(:ensure_restart)
+        end
 
-                context 'when the service has never been run' do
-                  before do
-                    expect_any_instance_of(Chef::Provider).not_to receive(:write_initd_ulimit)
-                    expect_any_instance_of(Chef::Provider).not_to receive(:ensure_restart)
-                  end
+        it 'should not change the ulimit' do
+          subject
+        end
+      end
+    end
+  end
+end
 
-                  it "should #{action} the Splunk service" do
-                    case action
-                    when 'start'
-                      expect(chef_run).to start_service(service_name)
-                    when 'restart'
-                      expect(chef_run).to restart_service(service_name)
-                    end
-                  end unless action == 'stop'
+describe 'splunk_service' do
+  let(:test_resource) { 'splunk_service' }
+  let(:test_recipe) { 'service_unit_test' }
 
-                  it 'should not stop the Splunk service' do
-                    expect(chef_run).not_to stop_service(service_name)
-                  end
-                end
+  environment_combinations.each do |platform, version, package, _|
+    describe "on #{platform} #{version}" do
+      describe "with package #{package}" do
+        let(:runner_params) { { platform: platform, version: version, user: 'root' } }
+        is_windows = platform == 'windows'
 
-                context 'when the service is running' do
-                  let(:running) { true }
+        let(:has_run) { true }
+        let(:ftr) { double('ftr_pathname') }
+        let(:init_script) { double('init_script_path') }
+        let(:service_name) do
+          if is_windows
+            package == :splunk ? 'splunkd' : 'splunkforwarder'
+          else
+            'splunk'
+          end
+        end
+        let(:cmd_prefix) { is_windows ? 'splunk.exe' : './splunk' }
 
-                  before do
-                    expect_any_instance_of(Chef::Provider).not_to receive(:write_initd_ulimit)
-                    expect_any_instance_of(Chef::Provider).not_to receive(:ensure_restart)
-                  end
+        let(:mock_run_state) { { 'splunk_ingredient' => { 'installations' => {} } } }
 
-                  it "should #{action} the Splunk service" do
-                    case action
-                    when 'start'
-                      expect(chef_run).to start_service(service_name)
-                    when 'stop'
-                      expect(chef_run).to stop_service(service_name)
-                    when 'restart'
-                      expect(chef_run).to restart_service(service_name)
-                    end
-                  end
-                end
+        let(:ftr_exists) { false }
+        let(:init_script_exists) { false }
+        let(:ftr_scope) { Chef::Resource }
+        let(:common_stubs) do
+          expect_any_instance_of(Chef::Resource).to receive(:check_restart)
+          expect_any_instance_of(ftr_scope).to receive(:ftr_pathname).and_return ftr
+          expect(ftr).to receive(:exist?).and_return ftr_exists
 
-                if platform == 'redhat' && %w(start restart).include?(action)
-                  context 'when the ulimit is specified' do
-                    let(:test_params) { { name: package.to_s, action: action.to_sym, ulimit: 4096 } }
-                    let(:expected_command) { "sh -c 'ulimit -n 4096 && ./splunk #{splunk_command}'" }
-                    it 'should set the ulimit' do
-                      expect_any_instance_of(Chef::Provider).to receive(:write_initd_ulimit).with(4096)
-                      chef_run
-                    end
+          expect_any_instance_of(Chef::Resource).to receive(:current_owner).and_return(is_windows ? nil : 'fauxhai')
+          expect_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return true
+          unless is_windows
+            expect_any_instance_of(Chef::Resource).to receive(:init_script_path).at_least(:once).and_return(init_script)
+            expect(init_script).to receive(:exist?).and_return init_script_exists
+          end
+        end
 
-                    context 'when the service is running' do
-                      let(:running) { true }
-                      it 'should restart the service' do
-                        expect_any_instance_of(Chef::Provider).to receive(:service_running).at_least(:once).and_return(true)
-                        expect_any_instance_of(Chef::Provider).to receive(:ensure_restart)
-                        expect_any_instance_of(Chef::Provider).to receive(:write_initd_ulimit).with(4096)
-                        chef_run
-                      end
-                    end if action == 'start'
+        let(:chef_run_stubs) do
+          common_stubs
+          action_stubs
+        end
 
-                    context 'when the ulimit is the same' do
-                      before do
-                        allow(init_script).to receive(:exist?).and_return(true)
-                        allow(init_script).to receive(:read).and_return(IO.read('spec/reference/splunk_initd'))
-                      end
-                      let(:test_params) { { name: package.to_s, action: action.to_sym, ulimit: 1024 } }
-                      it 'should not change the ulimit' do
-                        expect_any_instance_of(Chef::Provider).not_to receive(:write_initd_ulimit)
-                        expect(chef_run).not_to restart_splunk_service(package.to_s) if action == 'start'
-                        chef_run
-                      end
-                    end
-                  end
-                end
-              end
-            end
+        chef_context 'action :start' do
+          let(:test_params) { { name: package.to_s, action: :start } }
+          include_examples '*start examples', :start, platform, version, package
+        end
+
+        chef_context 'action :restart' do
+          let(:test_params) { { name: package.to_s, action: :restart } }
+          include_examples '*start examples', :restart, platform, version, package
+        end
+
+        chef_context 'action :stop' do
+          let(:action_stubs) {}
+          let(:ftr_scope) { Chef::Provider }
+          let(:test_params) { { name: package.to_s, action: :stop } }
+
+          it { is_expected.to stop_service(service_name) }
+
+          chef_context 'when the service has not been run for the first time' do
+            let(:ftr_exists) { true }
+            it { is_expected.not_to stop_service(service_name) }
           end
         end
       end

--- a/spec/unit/resources/splunk_service_spec.rb
+++ b/spec/unit/resources/splunk_service_spec.rb
@@ -80,8 +80,8 @@ describe 'splunk_service' do
   let(:test_recipe) { 'service_unit_test' }
 
   environment_combinations.each do |platform, version, package, _|
-    describe "on #{platform} #{version}" do
-      describe "with package #{package}" do
+    context "on #{platform} #{version}" do
+      context "with package #{package}" do
         let(:runner_params) { { platform: platform, version: version, user: 'root' } }
         is_windows = platform == 'windows'
 
@@ -120,17 +120,17 @@ describe 'splunk_service' do
           action_stubs
         end
 
-        chef_context 'action :start' do
+        chef_describe 'action :start' do
           let(:test_params) { { name: package.to_s, action: :start } }
           include_examples '*start examples', :start, platform, version, package
         end
 
-        chef_context 'action :restart' do
+        chef_describe 'action :restart' do
           let(:test_params) { { name: package.to_s, action: :restart } }
           include_examples '*start examples', :restart, platform, version, package
         end
 
-        chef_context 'action :stop' do
+        chef_describe 'action :stop' do
           let(:action_stubs) {}
           let(:ftr_scope) { Chef::Provider }
           let(:test_params) { { name: package.to_s, action: :stop } }

--- a/spec/unit/resources/splunk_service_spec.rb
+++ b/spec/unit/resources/splunk_service_spec.rb
@@ -1,5 +1,4 @@
 require_relative '../spec_helper'
-
 include CernerSplunk::ServiceHelpers, CernerSplunk::RestartHelpers
 
 shared_examples '*start examples' do |action, platform, _, package|

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -62,3 +62,19 @@ def environment_combinations
     end
   end
 end
+
+def chef_context(description, &blk)
+  context description do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new({ step_into: [test_resource] }.merge!(runner_params)) do |node|
+        node.normal['test_parameters'] = test_params
+        node.normal['run_state'].merge!(mock_run_state)
+        chef_run_stubs
+      end.converge('cerner_splunk_ingredient_test::' + test_recipe)
+    end
+
+    let(:run_state) { chef_run.node.run_state['splunk_ingredient'] }
+
+    subject { chef_run }
+  end.class_eval(&blk)
+end

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'rspec/expectations'
 require 'chefspec'
-require 'compat_resource'
 require 'chefspec/berkshelf'
 require 'chef/application'
 require_relative '../../libraries/path_helpers'

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -62,8 +62,8 @@ def environment_combinations
   end
 end
 
-def chef_context(description, &blk)
-  context description do
+def chef_context_block
+  proc do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new({ step_into: [test_resource] }.merge!(runner_params)) do |node|
         node.normal['test_parameters'] = test_params
@@ -75,5 +75,13 @@ def chef_context(description, &blk)
     let(:run_state) { chef_run.node.run_state['splunk_ingredient'] }
 
     subject { chef_run }
-  end.class_eval(&blk)
+  end
+end
+
+def chef_context(description, &blk)
+  context(description, &chef_context_block).class_eval(&blk)
+end
+
+def chef_describe(description, &blk)
+  describe(description, &chef_context_block).class_eval(&blk)
 end

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -64,7 +64,7 @@ end
 
 def chef_context_block
   proc do
-    let(:chef_run) do
+    cached(:chef_run) do
       ChefSpec::SoloRunner.new({ step_into: [test_resource] }.merge!(runner_params)) do |node|
         node.normal['test_parameters'] = test_params
         node.normal['run_state'].merge!(mock_run_state)

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -64,7 +64,7 @@ end
 
 def chef_context_block
   proc do
-    cached(:chef_run) do
+    let(:chef_run) do
       ChefSpec::SoloRunner.new({ step_into: [test_resource] }.merge!(runner_params)) do |node|
         node.normal['test_parameters'] = test_params
         node.normal['run_state'].merge!(mock_run_state)


### PR DESCRIPTION
Refactored the resource specs to use one-liners where possible, and use cached chef runs for all contexts. To aid in this, I opted to wrap the context method and provide a cached chef_run before the context is evaluated. This enables using one-liners (which generate their own examples) without a performance hit.

Unfortunately I could not refactor one-liners in everywhere, I realize now their only possible use is testing the state of a specific object. It does not work in any case where there are multiple or various subjects or where we are only testing that methods are called or errors are thrown. Thus, I did not touch the library specs. None of them have a case for one-liners or chef runs to be cached.
