### PR TITLE
Enhance splunk_conf Proc API

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,4 +1,21 @@
 ---
+_script: &PACKAGE_APP_SCRIPT
+    driver:
+      # Package the app for the test. Extra checks are necessary because we _must_ use GNU Tar for extracting in Windows.
+      pre_create_command: |
+        echo '## Packing test app...'
+        case "$(uname -s)" in
+          Darwin)
+            echo '## Mac detected, using gtar'
+            command -v gtar >/dev/null 2>&1 || { echo "You need to install gnu-tar to test app_upgrade. 'brew install gnu-tar'" >&2; exit 1; }
+            gtar -czvf test/files/pkg-app.spl -C test/files ./test_app
+            ;;
+          *)
+            echo '## Using tar'
+            tar -czvf test/files/pkg-app.spl -C test/files ./test_app
+            ;;
+        esac
+
 driver:
   name: vagrant
 
@@ -29,6 +46,7 @@ suites:
       - recipe[cerner_splunk_ingredient_test::splunk]
       - recipe[cerner_splunk_ingredient_test::uninstall_splunk]
   - name: install_forwarder
+    <<: *PACKAGE_APP_SCRIPT
     run_list:
       - recipe[cerner_splunk_ingredient_test::universal_forwarder]
   - name: uninstall_forwarder
@@ -43,21 +61,7 @@ suites:
       - recipe[cerner_splunk_ingredient_test::splunk_archive]
       - recipe[cerner_splunk_ingredient_test::uninstall_splunk_archive]
   - name: app_upgrade
-    driver:
-      # Package the app for the upgrade test. Extra checks are necessary because we _must_ use GNU Tar for extracting in Windows.
-      pre_create_command: |
-        echo '## Packing test app...'
-        case "$(uname -s)" in
-          Darwin)
-            echo '## Mac detected, using gtar'
-            command -v gtar >/dev/null 2>&1 || { echo "You need to install gnu-tar to test app_upgrade. 'brew install gnu-tar'" >&2; exit 1; }
-            gtar -czvf test/files/pkg-app.spl -C test/files ./test_app
-            ;;
-          *)
-            echo '## Using tar'
-            tar -czvf test/files/pkg-app.spl -C test/files ./test_app
-            ;;
-        esac
+    <<: *PACKAGE_APP_SCRIPT
     run_list:
       - recipe[cerner_splunk_ingredient_test::splunk]
       - recipe[cerner_splunk_ingredient_test::upgrade_splunk_app]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,5 +30,8 @@ Metrics/MethodLength:
 Style/MultilineIfModifier:
   Enabled: false
 
+Style/TrivialAccessors:
+ AllowDSLWriters: true
+
 Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,10 +17,6 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 120
 
-# Disabled for the Chef 12.13 integration tests which use an older Ruby.
-Style/NumericPredicate:
-  Enabled: false
-
 Style/FormatString:
   EnforcedStyle: percent
 
@@ -29,9 +25,6 @@ Metrics/MethodLength:
 
 Style/MultilineIfModifier:
   Enabled: false
-
-Style/TrivialAccessors:
- AllowDSLWriters: true
 
 Documentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ bundler_args: --without local
 rvm:
   - 2.3.1
 env:
-  - TEST_GROUP=6,5 CHEF_VERSION="<= 12.13.37"
-  - TEST_GROUP=6,5 CHEF_VERSION="~> 12.14"
-  - TEST_GROUP=1,3 CHEF_VERSION="<= 12.13.37"
-  - TEST_GROUP=1,3 CHEF_VERSION="~> 12.14"
-  - TEST_GROUP=2,4 CHEF_VERSION="<= 12.13.37"
-  - TEST_GROUP=2,4 CHEF_VERSION="~> 12.14"
+  - TEST_GROUP=1 CHEF_VERSION="~> 12.14"
+  - TEST_GROUP=2 CHEF_VERSION="~> 12.14"
+  - TEST_GROUP=3 CHEF_VERSION="~> 12.14"
+  - TEST_GROUP=4 CHEF_VERSION="~> 12.14"
+  - TEST_GROUP=5 CHEF_VERSION="~> 12.14"
+  - TEST_GROUP=6 CHEF_VERSION="~> 12.14"
 script:
   - bundle exec rubocop
   - bundle exec foodcritic -f any .

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://supermarket.chef.io'
 
 metadata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,38 @@
-# Feature Development:
-Developing for cerner_splunk_ingredient should follow these guidelines for submitting issues and pull requests.
+# Contributing Guidelines
 
-### Submitting Issues
-Issues pertaining to cerner_splunk_ingredient should be submitted to Github's issue tracker.
+Developing for cerner\_splunk\_ingredient should follow these guidelines for submitting issues and pull requests.
+
+## Submitting Issues
+
+Issues pertaining to cerner\_splunk\_ingredient should be submitted to Github's issue tracker.
 
 1. Issues will be triaged and marked with an appropriate label (e.g. bug, enhancement, question).
-  - A corresponding internal JIRA may be logged if there is a desire for internal discussion or code review.
-- The issue should be worked in a branch outside of the Cerner repo.
-- The issue will be marked for the next milestone following a pull request.
+1. A corresponding internal JIRA may be logged if there is a desire for internal discussion or code review.
+1. The issue should be worked in a branch outside of the Cerner repo.
+1. The issue will be marked for the next milestone following a pull request.
 
-### Pull Requests
+## Pull Requests
+
 Pull requests for changes should be compared against the 'stable' branch.
 
 1. Your branch should use as few logical commits as possible with descriptive commit messages.
-  - _Note: these commits should **not** reference any issues, that will be done in the merge commit._
-- Your pull request should reference the issue it is related to.
-- The pull request is collectively reviewed and commented on, and must get two or more +1's, from reviewers and at least one maintainer of the repo.
-  - Any raised comments must be addressed and will be re-reviewed.
-- Once the pull request is approved, the changes will be merged by a maintainer.
-    - This is done manually, not by using the Github button, so that the fix version of metadata.rb can be incremented in the merge. ([Example](https://github.com/cerner/cerner_splunk/issues/41#issuecomment-70569000))
-    - The merge commit text should reference the issue and the pull request so that both are closed when the merge is pushed.
+1. _Note: these commits should **not** reference any issues, that will be done in the merge commit._
+1. Your pull request should reference the issue it is related to.
+1. The pull request is collectively reviewed and commented on, and must get two or more +1's, from reviewers and at least one maintainer of the repo.
+   - Any raised comments must be addressed and will be re-reviewed.
+1. Once the pull request is approved, the changes will be merged by a maintainer.
+   - This is done manually, not by using the Github button, so that the fix version of metadata.rb can be incremented in the merge. ([Example](https://github.com/cerner/cerner_splunk/issues/41#issuecomment-70569000))
+   - The merge commit text should reference the issue and the pull request so that both are closed when the merge is pushed.
 
-# Release Process:
+## Releasing
+
 1. An issue is made to release a new version
-    - The issue will summarize what was changed since the last milestone, and propose the commit to tag and its description.
-    - The issue will be labeled "release"
-- The issue is reviewed, and must get two or more +1s from reviewers and maintainers.
-- An annotated tag is created with the reviewed release text.
-    - Master is set to the annotated tag.
-- The cookbook is released to Supermarket
-- Cleanup
-    - The issue and existing milestone is closed
-    - A new milestone is created for the next version
+1. The issue will summarize what was changed since the last milestone, and propose the commit to tag and its description.
+1. The issue will be labeled "release"
+1. The issue is reviewed, and must get two or more +1s from reviewers and maintainers.
+1. An annotated tag is created with the reviewed release text.
+   - Master is set to the annotated tag.
+1. The cookbook is released to Supermarket
+1. Cleanup
+   - The issue and existing milestone is closed
+   - A new milestone is created for the next version

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'berkshelf', '~> 5.3'

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 guard :rubocop do
   watch(/.+\.rb$/)
   watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }

--- a/README.md
+++ b/README.md
@@ -241,12 +241,11 @@ end
 
 ###### Section-level Evaluation
 
-section-level evaluation allows you to evaluate the config key values for a specific section without being
+Section-level evaluation allows you to evaluate the config key values for a specific section without being
 responsible for regurgitating all of the config you didn't want to modify.
 
 In this example, only a specific section's contents are turned into lowercase strings. The rest is
-merged as usual. **Note that the section-level proc receives the context and a props hash, and expects
-a pair (array) of the desired section name and props hash to be returned.**
+merged as usual.
 
 ```Ruby
 splunk_conf 'system/test.conf' do
@@ -255,7 +254,7 @@ splunk_conf 'system/test.conf' do
       one: 1,
       four: 4
     },
-    section: ->(context, props) { [context.section.to_s.downcase, props.map { |k, v| [k.to_s.downcase, v.to_s.downcase] }.to_h] }
+    section: ->(context, props) { props.map { |k, v| [k.to_s.downcase, v.to_s.downcase] }.to_h }
   )
 end
 ```
@@ -267,14 +266,13 @@ ease of use. This is especially handy when you want to produce some value for a 
 nesting the rest of the section in your Proc. If there is a case where you're applying a Proc to values whose keys you don't know,
 this becomes a necessary functionality.
 
-In this example, if the value is an Array object, it is converted into a comma spaced string using join. **Note that the Value-level proc
-receives the context and value, and expects a pair (array) of the desired key and value to be returned (similar to the section-level proc).**
+In this example, if the value is an Array object, it is converted into a comma spaced string using join.
 
 ```Ruby
 splunk_conf 'system/test.conf' do
   config(
     testing: {
-      servers: ->(context, value) { [context.key, value.is_a?(Array) ? value.join(', ') : value] }
+      servers: ->(context, value) { value.is_a?(Array) ? value.join(', ') : value }
     }
   )
 end
@@ -282,7 +280,7 @@ end
 
 ###### The Context object
 
-A ConfContext object is passed as the first parameter to any splunk_conf proc. It contains contextual information such as
+A ConfContext object is passed as the first parameter to any splunk\_conf proc. It contains contextual information such as
 path of the current file, current section (for section-level and key-level procs), and current key (for key-level procs).
 It also attempts to determine the current app from the path, if any.
 
@@ -294,7 +292,7 @@ Consider the value-level example above:
 splunk_conf 'system/test.conf' do
   config(
     testing: {
-      servers: ->(context, value) { [context.key, value.is_a?(Array) ? value.join(', ') : value] }
+      servers: ->(context, value) { value.is_a?(Array) ? value.join(', ') : value }
     }
   )
 end
@@ -311,7 +309,6 @@ lambda do |context, value|
   [context.key, value]
 end
 ```
-
 
 ### splunk\_restart
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These resources can:
 
 ## Requirements
 
-Chef >= 12.13.37
+Chef >= 12.14
 Ruby >= 2.3.1
 
 Supports Linux and Windows based systems with package support for Debian, Redhat,
@@ -30,7 +30,7 @@ Note: There are more specific resources available if you wish to override how Sp
 For example, if you want to force install from .rpm you can use splunk\_install\_redhat, or to install
 from archive (tgz for Linux and zip for Windows) use splunk\_install\_archive.
 
-#### Action *:install*
+#### Action _:install_
 
 Installs Splunk or Universal Forwarder.
 
@@ -51,7 +51,7 @@ Specific to splunk\_install\_archive
 | :----------- | :-----: | :------: | :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------ |
 | install\_dir |  String |    No    | Depends on platform and package | Manually specify the install directory for Splunk. This can only be done when installing from an archive, otherwise it will raise an error. |
 
-#### Action *:uninstall*
+#### Action _:uninstall_
 
 Removes Splunk or Universal Forwarder and all its configuration.
 
@@ -63,7 +63,7 @@ Properties:
 
 ##### Run State
 
-`splunk_install` *stores the current installation state to the [run state](https://docs.chef.io/recipes.html#node-run-state).*
+`splunk_install` _stores the current installation state to the [run state](https://docs.chef.io/recipes.html#node-run-state)._
 This contains data such as install directory and package so that subsequent resources can assume these values and avoid
 repetition. For example, you would be able to execute `splunk_conf` after a `splunk_install` and it will inherit the
 package of that last evaluated resource. If the install resource does nothing (installation already exists), it will
@@ -97,12 +97,12 @@ Manages an installation of Splunk. Requires splunk\_install to be evaluated firs
 
 **The following actions (start and restart) share the same properties:**
 
-#### Action *:start*
+#### Action _:start_
 
 Starts the Splunk daemon if not already running.
 If the ulimit is changed, invokes a restart of the daemon at the end of the run.
 
-#### Action *:restart*
+#### Action _:restart_
 
 Restarts the Splunk daemon, or starts it if not already running.
 
@@ -114,7 +114,7 @@ Properties:
 | install\_dir |                String               |                   No                  | Same as splunk\_install               | The install directory of Splunk. If you installed to a different directory than the default, you should provide this. If install\_dir is given, you do not need package.                                                                      |
 | ulimit       |               Integer               |                   No                  | Start up script ulimit or user ulimit | Open file ulimit to give Splunk. This sets the ulimit in the start up script (if it exists) and for the given user in `/etc/security/limits.d/`. -1 translates to `'unlimited'`                                                               |
 
-#### Action *:stop*
+#### Action _:stop_
 
 Stop the Splunk daemon if it is running.
 
@@ -125,7 +125,7 @@ Properties:
 | package      | `:splunk` or `:universal_forwarder` | **Yes, unless install\_dir is given** |                         | Specifies the installed Splunk package. If you did not specify the install\_dir, then you must specify the package, or name the resource for the package; for example, `package :splunk` or `splunk_service 'universal_forwarder' do ... end` |
 | install\_dir |                String               |                   No                  | Same as splunk\_install | The install directory of Splunk. If you installed to a different directory than the default, you should provide this. If install\_dir is given, you do not need package.                                                                      |
 
-#### Action *:init*
+#### Action _:init_
 
 Executes Splunk's first time run, accepting the license agreement if applicable. This does not start Splunk, only runs its initial setup.
 
@@ -140,7 +140,7 @@ Properties:
 
 Manages configuration for an installation of Splunk. Requires splunk\_install to be evaluated first.
 
-#### Action *:configure*
+#### Action _:configure_
 
 Applies configuration to .conf files.
 You should know where the .conf file is that you wish to modify, as you must provide the path from `$SPLUNK_HOME/etc`.
@@ -155,7 +155,7 @@ Properties:
 | path         |          String or Pathname         | **Yes (resource name)** |                                                  | Path of the .conf file from `$SPLUNK_HOME/etc`. The intermediate directory determining scope is optional. Examples: `system/indexes.conf` or `system/local/indexes.conf`.                                                                         |
 | package      | `:splunk` or `:universal_forwarder` |            No           | Package of the current install in run state      | Specifies the installed Splunk package. If you did not specify the install\_dir, then you may specify the package (`:splunk` or `:universal_forwarder`) otherwise the resource will refer to the most recently evaluated splunk\_install resource |
 | install\_dir |                String               |            No           | Path of the current install in run state         | The install directory of Splunk. If you installed to a different directory than the default, you should provide this. If install\_dir is given, you do not need package.                                                                          |
-| scope        |   `:local`, `:none`, or `:default`  |            No           | `:local`                                         | Scope of the configuration to modify. In most circumstances, you should *not* change this. `:none` will disable checking or modifying scope in the path.                                                                                          |
+| scope        |   `:local`, `:none`, or `:default`  |            No           | `:local`                                         | Scope of the configuration to modify. In most circumstances, you should _not_ change this. `:none` will disable checking or modifying scope in the path.                                                                                          |
 | config       |                 Hash                |         **Yes**         |                                                  | Configuration to apply to the .conf file. This hash is structured as follows: `{ section: { key: 'value' } }`. See below for more detailed explanation of the config property.                                                                    |
 | user         |            String or nil            |            No           | Owner of the current Splunk installation, if any | User that will be used to write to the .conf files.                                                                                                                                                                                               |
 | group        |            String or nil            |            No           | Group of the current Splunk installation, if any | Group that will be used to write to the .conf files.                                                                                                                                                                                              |
@@ -318,18 +318,18 @@ Chef run, it will notify a delayed restart as was intended in the previous run. 
 
 **The following actions all share the same properties:**
 
-#### Action *:ensure*
+#### Action _:ensure_
 
 Ensure that Splunk is restarted. This will notify for a delayed restart as well as place the file marker in case the Chef run fails
 before restarting Splunk. You should run this action in your cookbook when you intend to restart Splunk after a config change.
 
-*Note: When notifying this resource, do so with `:immediately`, otherwise it will effectively be the same as a normal delayed restart.*
+_Note: When notifying this resource, do so with `:immediately`, otherwise it will effectively be the same as a normal delayed restart._
 
-#### Action *:check*
+#### Action _:check_
 
 Checks if the file marker exists, and notifies for a delayed restart.
 
-#### Action *:clear*
+#### Action _:clear_
 
 Removes the file marker.
 
@@ -359,7 +359,7 @@ set a version in app.conf.
 
 Installs or updates a Splunk app from a package/archive.
 
-#### Action *:install*
+#### Action _:install_
 
 Install or upgrade a Splunk App.
 
@@ -390,7 +390,7 @@ Install or upgrade a Splunk App.
 | files        |                   Proc                   |              No             |                                             | Proc containing miscellaneous resources for manipulating the app directory. This is ideally directories, templates, and files. The Proc will be given an absolute app path parameter for you to use in these resources.                           |
 | metadata     |                   Hash                   |              No             | {}                                          | Configuration to apply to the metadata (local.meta for non-custom apps). See splunk\_conf for more info, and also below for special handling of the `access` key.                                                                                 |
 
-#### Action *:uninstall*
+#### Action _:uninstall_
 
 Uninstalls an app, completely removing it and its files.
 Note: You can use any sub-resource or `splunk_app` to uninstall apps.
@@ -425,7 +425,7 @@ splunk_app 'test_app' do
 end
 ```
 
-This helps when using programmatic values or large arrays of roles, though you *can* still use the appropriate string instead of the Hash syntax.
+This helps when using programmatic values or large arrays of roles, though you _can_ still use the appropriate string instead of the Hash syntax.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ The following statements would be true for the context object:
 
 ```Ruby
 lambda do |context, value|
-  context.path == '/opt/splunk/etc/system/test.conf'
-  context.app == nil
+  context.path == '/opt/splunk/etc/system/local/test.conf'
+  context.app == 'system'
   context.section == 'testing'
   context.key == 'servers'
   [context.key, value]

--- a/Thorfile
+++ b/Thorfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler'
 require 'bundler/setup'
 require 'berkshelf/thor'

--- a/libraries/conf_helpers.rb
+++ b/libraries/conf_helpers.rb
@@ -10,15 +10,15 @@ module CernerSplunk
 
     def self.evaluate_config(path, current_config, config)
       context = ConfContext.new(path)
-      evaluted_config = evaluate(config, context.freeze, current_config) || {}
+      evaluated_config = evaluate(config, context.freeze, current_config) || {}
 
-      evaluted_config.merge(evaluted_config) do |section, props|
+      evaluated_config.merge(evaluated_config) do |section, props|
         (section_context = context.dup).section = section
 
-        evaluted_props = evaluate(props, section_context.freeze, current_config.dig(section))
-        next if evaluted_props.nil?
+        evaluated_props = evaluate(props, section_context.freeze, current_config.dig(section))
+        next if evaluated_props.nil?
 
-        evaluted_props.merge(evaluted_props) do |key, value|
+        evaluated_props.merge(evaluated_props) do |key, value|
           (key_context = section_context.dup).key = key
           evaluate(value, key_context.freeze, current_config.dig(section, key))
         end

--- a/libraries/conf_helpers.rb
+++ b/libraries/conf_helpers.rb
@@ -59,6 +59,7 @@ module CernerSplunk
       (current_config.keys + desired_config.keys).uniq.each do |section|
         merged_config[section] = (current_config[section] || {}).merge(desired_config[section] || {})
       end
+      merged_config
     end
 
     def self.filter_config(config)

--- a/libraries/file_helpers.rb
+++ b/libraries/file_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CernerSplunk
   # Helper methods for file manipulation
   module FileHelpers

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 if defined?(ChefSpec)
   ChefSpec.define_matcher :splunk_install
   ChefSpec.define_matcher :splunk_service

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -5,6 +5,8 @@ if defined?(ChefSpec)
   ChefSpec.define_matcher :splunk_service
   ChefSpec.define_matcher :splunk_conf
   ChefSpec.define_matcher :splunk_restart
+  ChefSpec.define_matcher :splunk_app_custom
+  ChefSpec.define_matcher :splunk_app_package
 
   def install_splunk(name)
     ChefSpec::Matchers::ResourceMatcher.new(:splunk_install, :install, name)

--- a/libraries/path_helpers.rb
+++ b/libraries/path_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CernerSplunk
   # Helper methods for Splunk-related file and URL paths
   module PathHelpers

--- a/libraries/platform_helpers.rb
+++ b/libraries/platform_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CernerSplunk
   # Helper methods for platform oddities in Chef
   module PlatformHelpers

--- a/libraries/platform_helpers.rb
+++ b/libraries/platform_helpers.rb
@@ -7,7 +7,7 @@ module CernerSplunk
     #
     # @return [Boolean] whether or not the current system supports 64-bit
     def x64_support
-      %w(amd64 x86_64).include? node['kernel']['machine']
+      %w[amd64 x86_64].include? node['kernel']['machine']
     end
 
     # Provides constant defaults for Splunk's package names based on platform and package.

--- a/libraries/provider_helpers.rb
+++ b/libraries/provider_helpers.rb
@@ -27,6 +27,7 @@ module CernerSplunk
       end
 
       def backup_app
+        return unless app_path.exist?
         converge_by 'backing up existing app' do # ~FC005
           FileUtils.cp_r(app_path, app_cache_path + 'current')
         end

--- a/libraries/provider_helpers.rb
+++ b/libraries/provider_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CernerSplunk
   # Mixin Helper methods for Splunk Ingredient resources' providers
   module ProviderHelpers

--- a/libraries/provider_helpers.rb
+++ b/libraries/provider_helpers.rb
@@ -27,23 +27,15 @@ module CernerSplunk
       end
 
       def backup_app
-        return unless app_path.exist?
-        converge_by 'backing up existing app' do # ~FC005
-          FileUtils.cp_r(app_path, app_cache_path + 'current')
+        ruby_block 'backing up existing app' do
+          block do
+            FileUtils.cp_r(app_path, app_cache_path + 'current')
+          end
         end
       end
 
       def upgrade_keep_existing
-        declare_resource(:directory, app_path.to_s) do
-          action :nothing
-          recursive true
-        end.run_action :delete
-
-        converge_by 'installing new app version' do
-          FileUtils.mv(new_cache_path, app_path)
-        end
-
-        converge_by 'restoring local config' do
+        converge_by 'restoring local config' do # ~FC005
           existing_local = existing_cache_path + 'local'
           existing_local_meta = existing_cache_path + 'metadata/local.meta'
           new_local = new_cache_path + 'local'
@@ -55,6 +47,15 @@ module CernerSplunk
 
         converge_by "changing ownership of app to #{current_owner}:#{current_group}" do
           CernerSplunk::FileHelpers.deep_change_ownership(new_cache_path, current_owner, current_group)
+        end
+
+        declare_resource(:directory, app_path.to_s) do
+          action :nothing
+          recursive true
+        end.run_action :delete
+
+        converge_by 'installing new app version' do
+          FileUtils.mv(new_cache_path, app_path)
         end
       end
 

--- a/libraries/resource_helpers.rb
+++ b/libraries/resource_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CernerSplunk
   # Mixin Helper methods for Splunk Ingredient resources
   module ResourceHelpers

--- a/libraries/restart_helpers.rb
+++ b/libraries/restart_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CernerSplunk
   # Mixin Helper methods for Splunk Ingredient resources to ensure a service restart
   module RestartHelpers

--- a/libraries/service_helpers.rb
+++ b/libraries/service_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CernerSplunk
   # Mixin Helper methods for the Splunk Service resource
   module ServiceHelpers

--- a/libraries/service_helpers.rb
+++ b/libraries/service_helpers.rb
@@ -15,7 +15,7 @@ module CernerSplunk
       return unless pid_file.exist?
 
       pid = pid_file.readlines.first.to_i
-      pid > 0 ? pid : nil
+      pid.positive? ? pid : nil
     end
 
     # Reports if the daemon for the current package is running

--- a/libraries/splunk_version.rb
+++ b/libraries/splunk_version.rb
@@ -59,7 +59,7 @@ module CernerSplunk
       return 0 if self == other
 
       release_comp = compare_release_version(other)
-      release_comp == 0 && compare_prerelease(other) || release_comp
+      release_comp.zero? && compare_prerelease(other) || release_comp
     end
 
     private

--- a/libraries/splunk_version.rb
+++ b/libraries/splunk_version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CernerSplunk
   # Class object for parsing and encapsulating Splunk app versions
   class SplunkVersion

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 name             'cerner_splunk_ingredient'
 maintainer       'Cerner Innovation, Inc.'
 maintainer_email 'splunk@cerner.com'

--- a/resources/splunk_app.rb
+++ b/resources/splunk_app.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Cookbook Name:: cerner_splunk_ingredient
 # Resource:: splunk_app
 #
@@ -9,7 +10,7 @@ class SplunkApp < Chef::Resource
 
   property :name, String, name_property: true, identity: true
   property :install_dir, String, required: true, desired_state: false
-  property :package, [:splunk, :universal_forwarder], required: true, desired_state: false
+  property :package, %i(splunk universal_forwarder), required: true, desired_state: false
   property :app_root, [String, :shcluster, :master_apps], default: 'apps', desired_state: false
   property :version, [String, CernerSplunk::SplunkVersion]
   property :configs, Proc
@@ -91,6 +92,7 @@ class SplunkApp < Chef::Resource
 
     def apply_config
       node.run_state['splunk_ingredient']['conf_override'] = {
+        app: name,
         conf_path: (Pathname.new('apps') + name + config_scope).to_s,
         install_dir: install_dir,
         scope: :none

--- a/resources/splunk_app.rb
+++ b/resources/splunk_app.rb
@@ -6,7 +6,9 @@
 # Resource for installing and configuring Splunk apps
 
 class SplunkApp < Chef::Resource
-  include CernerSplunk::PlatformHelpers, CernerSplunk::PathHelpers, CernerSplunk::ResourceHelpers
+  include CernerSplunk::PlatformHelpers
+  include CernerSplunk::PathHelpers
+  include CernerSplunk::ResourceHelpers
 
   property :name, String, name_property: true, identity: true
   property :install_dir, String, required: true, desired_state: false

--- a/resources/splunk_app.rb
+++ b/resources/splunk_app.rb
@@ -94,7 +94,6 @@ class SplunkApp < Chef::Resource
 
     def apply_config
       node.run_state['splunk_ingredient']['conf_override'] = {
-        app: name,
         conf_path: (Pathname.new('apps') + name + config_scope).to_s,
         install_dir: install_dir,
         scope: :none

--- a/resources/splunk_app.rb
+++ b/resources/splunk_app.rb
@@ -12,7 +12,7 @@ class SplunkApp < Chef::Resource
 
   property :name, String, name_property: true, identity: true
   property :install_dir, String, required: true, desired_state: false
-  property :package, %i(splunk universal_forwarder), required: true, desired_state: false
+  property :package, %i[splunk universal_forwarder], required: true, desired_state: false
   property :app_root, [String, :shcluster, :master_apps], default: 'apps', desired_state: false
   property :version, [String, CernerSplunk::SplunkVersion]
   property :configs, Proc
@@ -143,7 +143,7 @@ class CustomApp < SplunkApp
       action :create
     end
 
-    %w(default local lookups metadata).each do |subdir|
+    %w[default local lookups metadata].each do |subdir|
       directory((app_path + subdir).to_s) do
         user current_owner
         group current_owner

--- a/resources/splunk_conf.rb
+++ b/resources/splunk_conf.rb
@@ -49,10 +49,6 @@ class SplunkConf < Chef::Resource
     path((Pathname.new(base_path) + Pathname.new(path).basename).to_s)
   end
 
-  def app(app_name)
-    @app = app_name
-  end
-
   load_current_value do |desired|
     if property_is_set? :install_dir
       install_dir desired.install_dir
@@ -79,8 +75,7 @@ class SplunkConf < Chef::Resource
     desired.path = Pathname.new(install_dir) + 'etc' + real_path.sub(%r{^/}, '')
     current_config = existing_config(desired.path)
 
-    context = CernerSplunk::ConfHelpers::ConfContext.new(desired.path, @app)
-    evaluated_config = CernerSplunk::ConfHelpers.evaluate_config(context, current_config, desired.config)
+    evaluated_config = CernerSplunk::ConfHelpers.evaluate_config(desired.path, current_config, desired.config)
     desired.config = CernerSplunk::ConfHelpers.stringify_config(evaluated_config)
 
     config reset ? current_config : current_config.select { |key, _| desired.config.keys.include? key.to_s }

--- a/resources/splunk_conf.rb
+++ b/resources/splunk_conf.rb
@@ -107,10 +107,13 @@ class SplunkConf < Chef::Resource
       action :create
     end
 
-    file new_resource.path.to_s do
+    merged_config = CernerSplunk::ConfHelpers.merge_config(reset ? {} : existing_config(new_resource.path), config)
+
+    template new_resource.path.to_s do # ~FC033 https://github.com/acrmp/foodcritic/issues/449
+      source 'conf.erb'
       owner config_user
       group config_group
-      content CernerSplunk::ConfHelpers.merge_config(reset ? {} : existing_config(new_resource.path), config)
+      variables config: CernerSplunk::ConfHelpers.filter_config(merged_config)
     end if changed?(:config)
   end
 end

--- a/resources/splunk_conf.rb
+++ b/resources/splunk_conf.rb
@@ -11,8 +11,8 @@ class SplunkConf < Chef::Resource
 
   property :path, [String, Pathname], name_property: true, desired_state: false, identity: true
   property :install_dir, String, required: true, desired_state: false
-  property :package, %i(splunk universal_forwarder), required: true, desired_state: false
-  property :scope, %i(local default none), desired_state: false, default: :local
+  property :package, %i[splunk universal_forwarder], required: true, desired_state: false
+  property :scope, %i[local default none], desired_state: false, default: :local
   property :config, Hash, required: true
   property :user, String, default: lazy { current_owner }
   property :group, String, default: lazy { current_group }

--- a/resources/splunk_conf.rb
+++ b/resources/splunk_conf.rb
@@ -111,6 +111,7 @@ class SplunkConf < Chef::Resource
 
     template new_resource.path.to_s do # ~FC033 https://github.com/acrmp/foodcritic/issues/449
       source 'conf.erb'
+      cookbook 'cerner_splunk_ingredient'
       owner config_user
       group config_group
       variables config: CernerSplunk::ConfHelpers.filter_config(merged_config)

--- a/resources/splunk_install.rb
+++ b/resources/splunk_install.rb
@@ -13,7 +13,7 @@ class SplunkInstall < Chef::Resource
   resource_name :splunk_install
 
   property :name, String, name_property: true, identity: true
-  property :package, %i(splunk universal_forwarder), required: true
+  property :package, %i[splunk universal_forwarder], required: true
   property :version, String, required: true
   property :build, String, required: true
   property :install_dir, String, required: true, desired_state: false
@@ -151,7 +151,7 @@ end
 
 class ArchiveInstall < SplunkInstall
   resource_name :splunk_install_archive
-  provides :splunk_install, os: %w(linux windows)
+  provides :splunk_install, os: %w[linux windows]
 
   def kernel_string
     case node['os']

--- a/resources/splunk_install.rb
+++ b/resources/splunk_install.rb
@@ -6,7 +6,9 @@
 # Resource for managing the installation of Splunk
 
 class SplunkInstall < Chef::Resource
-  include CernerSplunk::PlatformHelpers, CernerSplunk::PathHelpers, CernerSplunk::ResourceHelpers
+  include CernerSplunk::PlatformHelpers
+  include CernerSplunk::PathHelpers
+  include CernerSplunk::ResourceHelpers
 
   resource_name :splunk_install
 

--- a/resources/splunk_install.rb
+++ b/resources/splunk_install.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Cookbook Name:: cerner_splunk_ingredient
 # Resource:: splunk_install
 #
@@ -10,7 +11,7 @@ class SplunkInstall < Chef::Resource
   resource_name :splunk_install
 
   property :name, String, name_property: true, identity: true
-  property :package, [:splunk, :universal_forwarder], required: true
+  property :package, %i(splunk universal_forwarder), required: true
   property :version, String, required: true
   property :build, String, required: true
   property :install_dir, String, required: true, desired_state: false

--- a/resources/splunk_restart.rb
+++ b/resources/splunk_restart.rb
@@ -36,8 +36,10 @@ class SplunkRestart < Chef::Resource
       install_dir desired.install_dir
       package desired.package = install_state['package']
     else
+      current_state = node.run_state['splunk_ingredient']['current_installation'] || {}
+      desired.package = current_state['package'] unless property_is_set? :package
       package desired.package
-      install_dir default_install_dir
+      install_dir desired.install_dir = (current_state['path'] || default_install_dir)
       install_state
     end
 

--- a/resources/splunk_restart.rb
+++ b/resources/splunk_restart.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Cookbook Name:: cerner_splunk_ingredient
 # Resource:: splunk_restart
 #
@@ -11,7 +12,7 @@ class SplunkRestart < Chef::Resource
 
   property :name, String, name_property: true, desired_state: false, identity: true
   property :install_dir, String, required: true, desired_state: false
-  property :package, [:splunk, :universal_forwarder], required: true
+  property :package, %i(splunk universal_forwarder), required: true
 
   default_action :check
 

--- a/resources/splunk_restart.rb
+++ b/resources/splunk_restart.rb
@@ -12,7 +12,7 @@ class SplunkRestart < Chef::Resource
 
   property :name, String, name_property: true, desired_state: false, identity: true
   property :install_dir, String, required: true, desired_state: false
-  property :package, %i(splunk universal_forwarder), required: true
+  property :package, %i[splunk universal_forwarder], required: true
 
   default_action :check
 

--- a/resources/splunk_service.rb
+++ b/resources/splunk_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Cookbook Name:: cerner_splunk_ingredient
 # Resource:: splunk_service
 #
@@ -12,7 +13,7 @@ class SplunkService < Chef::Resource
 
   property :name, String, name_property: true, desired_state: false, identity: true
   property :install_dir, String, required: true, desired_state: false
-  property :package, [:splunk, :universal_forwarder], required: true
+  property :package, %i(splunk universal_forwarder), required: true
   property :ulimit, Integer
 
   default_action :start

--- a/resources/splunk_service.rb
+++ b/resources/splunk_service.rb
@@ -15,7 +15,7 @@ class SplunkService < Chef::Resource
 
   property :name, String, name_property: true, desired_state: false, identity: true
   property :install_dir, String, required: true, desired_state: false
-  property :package, %i(splunk universal_forwarder), required: true
+  property :package, %i[splunk universal_forwarder], required: true
   property :ulimit, Integer
 
   default_action :start
@@ -54,7 +54,7 @@ class SplunkService < Chef::Resource
     unless node['os'] == 'windows'
       if init_script_path.exist?
         limit = init_script_path.read[/ulimit -n (\d+)/, 1].to_i
-        ulimit limit if limit > 0
+        ulimit limit if limit.positive?
       end
     end
   end

--- a/resources/splunk_service.rb
+++ b/resources/splunk_service.rb
@@ -6,8 +6,10 @@
 # Resource for managing Splunk as a system service
 
 class SplunkService < Chef::Resource
-  include CernerSplunk::PlatformHelpers, CernerSplunk::ResourceHelpers,
-          CernerSplunk::ServiceHelpers, CernerSplunk::RestartHelpers
+  include CernerSplunk::PlatformHelpers
+  include CernerSplunk::ResourceHelpers
+  include CernerSplunk::ServiceHelpers
+  include CernerSplunk::RestartHelpers
 
   resource_name :splunk_service
 

--- a/spec/reference/write_test_delete_section.conf
+++ b/spec/reference/write_test_delete_section.conf
@@ -1,0 +1,9 @@
+# Warning: This file is managed by Chef!
+# Comments will not be preserved and configuration may be overwritten.
+
+[default]
+first = false
+second = true
+
+[another]
+something = there

--- a/spec/reference/write_test_delete_value.conf
+++ b/spec/reference/write_test_delete_value.conf
@@ -1,0 +1,11 @@
+# Warning: This file is managed by Chef!
+# Comments will not be preserved and configuration may be overwritten.
+
+[default]
+first = false
+second = true
+
+[other]
+
+[another]
+something = there

--- a/spec/unit/libraries/conf_helpers_spec.rb
+++ b/spec/unit/libraries/conf_helpers_spec.rb
@@ -103,7 +103,8 @@ describe 'ConfHelpers' do
           b: 1000,
           c: {
             deep: :deep
-          }
+          },
+          d: nil
         },
         'two' => {
           even: 'more'
@@ -115,7 +116,8 @@ describe 'ConfHelpers' do
         'one' => {
           'a' => 'string',
           'b' => '1000',
-          'c' => '{:deep=>:deep}'
+          'c' => '{:deep=>:deep}',
+          'd' => nil
         },
         'two' => {
           'even' => 'more'
@@ -183,59 +185,63 @@ describe 'ConfHelpers' do
     let(:config) do
       {
         'default' => {
-          'first' => 'false'
+          'first' => nil
         },
         'another' => {
           'something' => 'there'
         }
       }
     end
-    let(:expected_config) { IO.read('spec/reference/write_test.conf') }
+    let(:expected_config) do
+      {
+        'default' => {
+          'first' => 'false',
+          'second' => 'true'
+        },
+        'another' => {
+          'something' => 'there'
+        },
+        'other' => {
+          'something' => 'here'
+        }
+      }
+    end
 
     it { is_expected.to eq expected_config }
 
     context 'when current_config is empty' do
-      let(:expected_config) { IO.read('spec/reference/write_test_overwrite.conf') }
-
-      it 'should write only the given config to the file' do
-        expect(CernerSplunk::ConfHelpers.merge_config({}, config)).to eq expected_config
+      it 'should return only the given config' do
+        expect(CernerSplunk::ConfHelpers.merge_config({}, config)).to eq config
       end
     end
+  end
 
-    context 'when a given section is nil' do
-      let(:config) do
-        {
-          'default' => {
-            'first' => 'false'
-          },
-          'other' => nil,
-          'another' => {
-            'something' => 'there'
-          }
+  describe 'filter_config' do
+    subject { CernerSplunk::ConfHelpers.filter_config(config) }
+    let(:config) do
+      {
+        'default' => {
+          'first' => ''
+        },
+        'other' => nil,
+        'another' => {
+          'something' => 'there',
+          'else' => nil
         }
-      end
-      let(:expected_config) { IO.read('spec/reference/write_test_delete_section.conf') }
-
-      it { is_expected.to eq expected_config }
+      }
     end
 
-    context 'when a given value is nil' do
-      let(:config) do
-        {
-          'default' => {
-            'first' => 'false'
-          },
-          'other' => {
-            'something' => nil
-          },
-          'another' => {
-            'something' => 'there'
-          }
+    let(:expected_config) do
+      {
+        'default' => {
+          'first' => ''
+        },
+        'another' => {
+          'something' => 'there'
         }
-      end
-      let(:expected_config) { IO.read('spec/reference/write_test_delete_value.conf') }
-
-      it { is_expected.to eq expected_config }
+      }
     end
+
+    it { is_expected.to eq expected_config }
   end
 end

--- a/spec/unit/libraries/conf_helpers_spec.rb
+++ b/spec/unit/libraries/conf_helpers_spec.rb
@@ -17,8 +17,7 @@ describe 'ConfHelpers' do
   end
 
   describe 'evaluate_config' do
-    let(:conf_context) { CernerSplunk::ConfHelpers::ConfContext.new(conf_path) }
-    subject { CernerSplunk::ConfHelpers.evaluate_config(conf_context, existing_config, config) }
+    subject { CernerSplunk::ConfHelpers.evaluate_config(conf_path, existing_config, config) }
 
     context 'with top-level proc' do
       let!(:actual_context) {}
@@ -27,7 +26,7 @@ describe 'ConfHelpers' do
           conf.map { |section, props| [section.upcase, props] }.to_h.merge('context' => { 'context' => context })
         end
       end
-      let(:expected_context) { CernerSplunk::ConfHelpers::ConfContext.new(conf_path, 'system') }
+      let(:expected_context) { CernerSplunk::ConfHelpers::ConfContext.new(conf_path) }
       let(:expected_config) do
         {
           'context' => { 'context' => expected_context },
@@ -53,7 +52,7 @@ describe 'ConfHelpers' do
           'other' => ->(context, props) { [context.stanza.upcase, props.merge('context' => context)] }
         }
       end
-      let(:expected_context) { CernerSplunk::ConfHelpers::ConfContext.new(conf_path, 'system', 'other') }
+      let(:expected_context) { CernerSplunk::ConfHelpers::ConfContext.new(conf_path, 'other') }
       let(:expected_config) do
         {
           'default' => {
@@ -76,18 +75,18 @@ describe 'ConfHelpers' do
             'second' => 'false'
           },
           'other' => {
-            'something' => ->(context, _) { [context.key, context] }
+            'something' => ->(context, _) { [context.app, context] }
           }
         }
       end
-      let(:expected_context) { CernerSplunk::ConfHelpers::ConfContext.new(conf_path, 'system', 'other', 'something') }
+      let(:expected_context) { CernerSplunk::ConfHelpers::ConfContext.new(conf_path, 'other', 'something') }
       let(:expected_config) do
         {
           'default' => {
             'second' => 'false'
           },
           'other' => {
-            'something' => expected_context
+            'system' => expected_context
           }
         }
       end

--- a/spec/unit/libraries/conf_helpers_spec.rb
+++ b/spec/unit/libraries/conf_helpers_spec.rb
@@ -43,13 +43,13 @@ describe 'ConfHelpers' do
       it { is_expected.to eq(expected_config) }
     end
 
-    context 'with stanza-level proc' do
+    context 'with section-level proc' do
       let(:config) do
         {
           'default' => {
             'second' => 'false'
           },
-          'other' => ->(context, props) { [context.stanza.upcase, props.merge('context' => context)] }
+          'other' => ->(context, props) { [context.section.upcase, props.merge('context' => context)] }
         }
       end
       let(:expected_context) { CernerSplunk::ConfHelpers::ConfContext.new(conf_path, 'other') }

--- a/spec/unit/libraries/conf_helpers_spec.rb
+++ b/spec/unit/libraries/conf_helpers_spec.rb
@@ -195,7 +195,7 @@ describe 'ConfHelpers' do
     let(:expected_config) do
       {
         'default' => {
-          'first' => 'false',
+          'first' => nil,
           'second' => 'true'
         },
         'another' => {

--- a/spec/unit/libraries/path_helpers_spec.rb
+++ b/spec/unit/libraries/path_helpers_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 describe 'PathHelpers' do

--- a/spec/unit/libraries/resource_helpers_spec.rb
+++ b/spec/unit/libraries/resource_helpers_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 describe 'ResourceHelpers' do

--- a/spec/unit/libraries/service_helpers_spec.rb
+++ b/spec/unit/libraries/service_helpers_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 describe 'ServiceHelpers' do

--- a/spec/unit/libraries/service_helpers_spec.rb
+++ b/spec/unit/libraries/service_helpers_spec.rb
@@ -46,7 +46,7 @@ describe 'ServiceHelpers' do
         end
 
         it 'should return nil if a valid pid is not read' do
-          expect(splunk_pid_path).to receive(:readlines).and_return %w(abcd5 g g)
+          expect(splunk_pid_path).to receive(:readlines).and_return %w[abcd5 g g]
           expect(service_pid).to be_nil
         end
       end

--- a/spec/unit/libraries/splunk_version_spec.rb
+++ b/spec/unit/libraries/splunk_version_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rspec/its'
 require_relative '../spec_helper'
 require_relative '../../../libraries/splunk_version'

--- a/spec/unit/resources/install_examples.rb
+++ b/spec/unit/resources/install_examples.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 shared_examples 'should install' do |platform, expected_url|
   it { is_expected.to create_remote_file(package_path).with(source: expected_url) }
   it { is_expected.to run_ruby_block('load_version_state') }

--- a/spec/unit/resources/splunk_app_spec.rb
+++ b/spec/unit/resources/splunk_app_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../spec_helper'
 include CernerSplunk::ResourceHelpers
 

--- a/spec/unit/resources/splunk_app_spec.rb
+++ b/spec/unit/resources/splunk_app_spec.rb
@@ -129,17 +129,13 @@ describe 'splunk_app' do
               let(:package_path) { Pathname.new(app_cache_path) + 'my_app.tgz' }
               let(:existing_cache_path) { Pathname.new(app_cache_path) + 'current' }
               let(:new_cache_path) { Pathname.new(app_cache_path) + 'new' }
-              let(:action_stubs) do
-                if upgrade
-                  # Backup App
-                  expect(FileUtils).to receive(:cp_r).with(app_path, existing_cache_path)
-                end
-              end
               it do
                 if upgrade
                   is_expected.to run_ruby_block('upgrade app')
+                  is_expected.to run_ruby_block('backing up existing app')
                 else
                   is_expected.not_to run_ruby_block('upgrade app')
+                  is_expected.not_to run_ruby_block('backing up existing app')
                 end
               end
               it { is_expected.to create_remote_file(package_path).with(source: source_url) }

--- a/spec/unit/resources/splunk_app_spec.rb
+++ b/spec/unit/resources/splunk_app_spec.rb
@@ -25,7 +25,7 @@ describe 'splunk_app' do
     }
   end
 
-  %w(splunk_app splunk_app_custom splunk_app_package).each do |resource|
+  %w[splunk_app splunk_app_custom splunk_app_package].each do |resource|
     describe resource do
       let(:test_resource) { resource }
       let(:test_recipe) { 'app_unit_test' }
@@ -69,7 +69,7 @@ describe 'splunk_app' do
             },
             'views' => {
               'owner' => 'admin',
-              'access' => { 'read' => '*', 'write' => %w(admin power) }
+              'access' => { 'read' => '*', 'write' => %w[admin power] }
             }
           }
         end

--- a/spec/unit/resources/splunk_conf_spec.rb
+++ b/spec/unit/resources/splunk_conf_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../spec_helper'
 include CernerSplunk::ResourceHelpers
 

--- a/spec/unit/resources/splunk_conf_spec.rb
+++ b/spec/unit/resources/splunk_conf_spec.rb
@@ -36,6 +36,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
       expect_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return true
       expect(CernerSplunk::ConfHelpers).to receive(:read_config).with(conf_path).and_return(existing_config)
       expect(CernerSplunk::ConfHelpers).to receive(:merge_config).with(existing_config, expected_config).and_return 'merged config'
+      expect(CernerSplunk::ConfHelpers).to receive(:filter_config).with('merged config').and_return 'merged config'
       allow_any_instance_of(Chef::Resource).to receive(:current_owner).and_return(platform == 'windows' ? 'administrator' : 'fauxhai')
       allow_any_instance_of(Chef::Resource).to receive(:current_group).and_return(platform == 'windows' ? 'host\NONE' : 'fauxhai')
     end
@@ -66,7 +67,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
       end
 
       it { is_expected.to configure_splunk('system/test.conf').with expected_params }
-      it { is_expected.to create_file(conf_path).with(content: 'merged config', owner: package.to_s) }
+      it { is_expected.to create_template(conf_path).with(source: 'conf.erb', variables: { config: 'merged config' }, owner: package.to_s) }
       it { is_expected.to init_splunk_service('init_before_config') }
     end
 
@@ -182,7 +183,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
         end
 
         it { is_expected.to configure_splunk('system/test.conf').with expected_params }
-        it { is_expected.to create_file(conf_path).with(content: 'merged config', owner: package.to_s) }
+        it { is_expected.to create_template(conf_path).with(source: 'conf.erb', variables: { config: 'merged config' }, owner: package.to_s) }
         it { is_expected.to init_splunk_service('init_before_config') }
       end
 
@@ -256,7 +257,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
       end
 
       it { is_expected.to configure_splunk('system/test.conf') }
-      it { is_expected.to create_file(conf_path).with(content: 'merged config', owner: platform == 'windows' ? 'administrator' : 'fauxhai') }
+      it { is_expected.to create_template(conf_path).with(source: 'conf.erb', variables: { config: 'merged config' }, owner: platform == 'windows' ? 'administrator' : 'fauxhai') }
     end
 
     chef_context 'when reset is specified' do
@@ -275,11 +276,12 @@ shared_examples 'splunk_conf' do |platform, version, package|
         expect_any_instance_of(Chef::Resource).to receive(:load_installation_state).and_return true
         expect(CernerSplunk::ConfHelpers).to receive(:read_config).with(conf_path).and_return(existing_config)
         expect(CernerSplunk::ConfHelpers).to receive(:merge_config).with({}, expected_config).and_return 'just my config'
+        expect(CernerSplunk::ConfHelpers).to receive(:filter_config).with('just my config').and_return 'just my config'
         allow_any_instance_of(Chef::Resource).to receive(:current_group).and_return(platform == 'windows' ? 'host\NONE' : 'fauxhai')
       end
 
       it { is_expected.to configure_splunk('system/test.conf') }
-      it { is_expected.to create_file(conf_path).with(content: 'just my config', owner: package.to_s) }
+      it { is_expected.to create_template(conf_path).with(source: 'conf.erb', variables: { config: 'just my config' }, owner: package.to_s) }
     end
 
     chef_context 'when conf_override is set in the run state' do
@@ -321,7 +323,7 @@ shared_examples 'splunk_conf' do |platform, version, package|
       let(:conf_path) { Pathname.new(install_dir) + 'etc/apps/test_app/local/test.conf' }
 
       it { is_expected.to configure_splunk('system/test.conf') }
-      it { is_expected.to create_file(conf_path).with(content: 'merged config', owner: 'otherbody') }
+      it { is_expected.to create_template(conf_path).with(source: 'conf.erb', variables: { config: 'merged config' }, owner: 'otherbody') }
     end
   end
 end

--- a/spec/unit/resources/splunk_install_spec.rb
+++ b/spec/unit/resources/splunk_install_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_relative 'install_examples'
 

--- a/spec/unit/resources/splunk_restart_spec.rb
+++ b/spec/unit/resources/splunk_restart_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../spec_helper'
 include CernerSplunk::RestartHelpers
 

--- a/spec/unit/resources/splunk_service_spec.rb
+++ b/spec/unit/resources/splunk_service_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../spec_helper'
 include CernerSplunk::ServiceHelpers, CernerSplunk::RestartHelpers
 

--- a/spec/unit/resources/splunk_service_spec.rb
+++ b/spec/unit/resources/splunk_service_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../spec_helper'
-include CernerSplunk::ServiceHelpers, CernerSplunk::RestartHelpers
+include CernerSplunk::ServiceHelpers
+include CernerSplunk::RestartHelpers
 
 shared_examples '*start examples' do |action, platform, _, package|
   is_windows = platform == 'windows'

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -4,7 +4,7 @@ require 'rspec/expectations'
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'chef/application'
-%w(path platform resource restart service conf file provider).each { |helper| require_relative "../../libraries/#{helper}_helpers" }
+%w[path platform resource restart service conf file provider].each { |helper| require_relative "../../libraries/#{helper}_helpers" }
 
 RSpec.configure do |config|
   config.extend(ChefSpec::Cacher)

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rspec/expectations'
 require 'chefspec'
 require 'chefspec/berkshelf'

--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -1,7 +1,7 @@
 # Warning: This file is managed by Chef!
 # Comments will not be preserved and configuration may be overwritten.
 
-<% config.each do |section, props| -%>
+<% @config.each do |section, props| -%>
 [<%=section%>]
 <%   props.each do |key, value| -%>
 <%=key%> = <%=value%>

--- a/templates/conf.erb
+++ b/templates/conf.erb
@@ -1,0 +1,9 @@
+# Warning: This file is managed by Chef!
+# Comments will not be preserved and configuration may be overwritten.
+
+<% config.each do |section, props| -%>
+[<%=section%>]
+<%   props.each do |key, value| -%>
+<%=key%> = <%=value%>
+<%   end -%>
+<% end -%>

--- a/test/cookbooks/cerner_splunk_ingredient_test/README.md
+++ b/test/cookbooks/cerner_splunk_ingredient_test/README.md
@@ -1,3 +1,3 @@
-cerner_splunk_ingredient_test Cookbook
-=================================
+# cerner\_splunk\_ingredient\_test Cookbook
+
 Recipes for unit and integration testing

--- a/test/cookbooks/cerner_splunk_ingredient_test/metadata.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/metadata.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 name             'cerner_splunk_ingredient_test'
 maintainer       'Cerner Innovation, Inc.'
 maintainer_email 'splunk@cerner.com'

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/app_unit_test.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/app_unit_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 node.run_state.merge! node['run_state'].to_hash if node['run_state']
 
 params = node['test_parameters'].to_hash

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/config_unit_test.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/config_unit_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 node.run_state.merge! node['run_state'].to_hash if node['run_state']
 
 params = node['test_parameters'].to_hash

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/install_archive_unit_test.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/install_archive_unit_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 node.run_state.merge! node['run_state'].to_hash if node['run_state']
 
 params = node['test_parameters'].to_hash

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/install_unit_test.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/install_unit_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 node.run_state.merge! node['run_state'].to_hash if node['run_state']
 
 params = node['test_parameters'].to_hash

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/restart_unit_test.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/restart_unit_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 node.run_state.merge! node['run_state'].to_hash if node['run_state']
 
 params = node['test_parameters'].to_hash

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/service_unit_test.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/service_unit_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 node.run_state.merge! node['run_state'].to_hash if node['run_state']
 
 params = node['test_parameters'].to_hash

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/splunk.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/splunk.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 splunk_install 'splunk' do
   version '6.3.4'
   build 'cae2458f4aef'

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/splunk.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/splunk.rb
@@ -37,7 +37,7 @@ splunk_app_custom 'test_app' do
     end
   end)
   metadata(
-    views: { access: { read: '*', write: %w(admin power) } },
+    views: { access: { read: '*', write: %w[admin power] } },
     'views/index_check' => { access: { read: 'admin', write: 'admin' } }
   )
 end

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/splunk.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/splunk.rb
@@ -6,6 +6,10 @@ splunk_install 'splunk' do
   base_url 'http://download.splunk.com/products'
 end
 
+splunk_restart 'splunk' do
+  action :nothing
+end
+
 splunk_conf 'system/indexes.conf' do
   config(
     test_index: {
@@ -40,4 +44,5 @@ splunk_app_custom 'test_app' do
     views: { access: { read: '*', write: %w[admin power] } },
     'views/index_check' => { access: { read: 'admin', write: 'admin' } }
   )
+  notifies :ensure, 'splunk_restart[splunk]', :immediately
 end

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/splunk_archive.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/splunk_archive.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 node.default['splunk']['install_dir'] = node['os'] == 'windows' ? 'c:\splunk' : '/etc/splunk'
 
 splunk_install_archive 'splunk' do

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/uninstall_splunk.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/uninstall_splunk.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 splunk_install 'splunk' do
   action :uninstall
 end

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/uninstall_splunk_archive.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/uninstall_splunk_archive.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 splunk_install_archive 'splunk' do
   install_dir node['splunk']['install_dir']
   action :uninstall

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/uninstall_universal_forwarder.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/uninstall_universal_forwarder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 splunk_install 'universal_forwarder' do
   action :uninstall
 end

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/universal_forwarder.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/universal_forwarder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+app_url = platform_family?('windows') ? 'file:///C:/Users/Vagrant/AppData/Local/Temp/kitchen/data/pkg-app.spl' : 'file:///tmp/kitchen/data/pkg-app.spl'
+
 splunk_install 'universal_forwarder' do
   user 'splunkforwarder' unless platform_family? 'windows'
   version '6.3.4'
@@ -16,4 +18,18 @@ end
 
 splunk_service 'universal_forwarder' do
   ulimit 3000
+end
+
+splunk_app_package 'test_app' do
+  source_url app_url
+  version '1.2.0'
+  configs(proc do
+    splunk_conf 'testing.conf' do
+      config(debug: { banana: 'yellow' })
+    end
+  end)
+  metadata(
+    views: { access: { read: '*', write: %w[admin power] } },
+    'views/index_check' => { access: { read: 'admin', write: 'admin' } }
+  )
 end

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/universal_forwarder.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/universal_forwarder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 splunk_install 'universal_forwarder' do
   user 'splunkforwarder' unless platform_family? 'windows'
   version '6.3.4'

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/upgrade_splunk_app.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/upgrade_splunk_app.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 app_url = platform_family?('windows') ? 'file:///C:/Users/Vagrant/AppData/Local/Temp/kitchen/data/pkg-app.spl' : 'file:///tmp/kitchen/data/pkg-app.spl'
 
 splunk_app_package 'test_app' do

--- a/test/cookbooks/cerner_splunk_ingredient_test/recipes/upgrade_splunk_app.rb
+++ b/test/cookbooks/cerner_splunk_ingredient_test/recipes/upgrade_splunk_app.rb
@@ -11,7 +11,7 @@ splunk_app_package 'test_app' do
     end
   end)
   metadata(
-    views: { access: { read: '*', write: %w(admin power) } },
+    views: { access: { read: '*', write: %w[admin power] } },
     'views/index_check' => { access: { read: 'admin', write: 'admin' } }
   )
 end

--- a/test/integration/app_upgrade/spec.rb
+++ b/test/integration/app_upgrade/spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 windows = os.windows?
 splunk_path = windows ? 'c:\Program Files\Splunk' : '/opt/splunk'
 

--- a/test/integration/archive_install/spec.rb
+++ b/test/integration/archive_install/spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 windows = os.windows?
 splunk_path = windows ? 'c:\splunk' : '/etc/splunk'
 splunk_command = windows ? "& \"#{splunk_path}\\bin\\splunk.exe\"" : "#{splunk_path}/bin/splunk"

--- a/test/integration/archive_uninstall/spec.rb
+++ b/test/integration/archive_uninstall/spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 windows = os.windows?
 
 describe service(windows ? 'splunkd' : 'splunk') do

--- a/test/integration/install/spec.rb
+++ b/test/integration/install/spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 windows = os.windows?
 splunk_path = windows ? 'c:\Program Files\Splunk' : '/opt/splunk'
 splunk_command = windows ? "& \"#{splunk_path}\\bin\\splunk.exe\"" : "#{splunk_path}/bin/splunk"

--- a/test/integration/install_forwarder/spec.rb
+++ b/test/integration/install_forwarder/spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 windows = os.windows?
 splunk_path = windows ? 'c:\Program Files\SplunkUniversalForwarder' : '/opt/splunkforwarder'
 splunk_command = windows ? "& \"#{splunk_path}\\bin\\splunk.exe\"" : "#{splunk_path}/bin/splunk"

--- a/test/integration/install_forwarder/spec.rb
+++ b/test/integration/install_forwarder/spec.rb
@@ -46,3 +46,60 @@ unless windows
     its('stdout') { is_expected.to match(/^Max open files \s+ \w+ \s+ 3000 \s+ files\s*$/m) }
   end
 end
+
+test_app_path = Pathname.new(splunk_path) + 'etc/apps/test_app'
+
+describe file(test_app_path.to_s) do
+  it { is_expected.to be_directory }
+  its('owner') { is_expected.to match(/splunkforwarder$/) } unless windows
+end
+
+describe file((test_app_path + 'default/testing.conf').to_s) do
+  it { is_expected.not_to be_file }
+end
+
+describe file((test_app_path + 'local/testing.conf').to_s) do
+  it { is_expected.to be_file }
+  its('owner') { is_expected.to match(/splunkforwarder$/) } unless windows
+
+  its('content') { is_expected.to match(/\[debug\]/) }
+  its('content') { is_expected.to match(/banana = yellow/) }
+end
+
+describe file((test_app_path + 'default/app.conf').to_s) do
+  it { is_expected.to be_file }
+  its('owner') { is_expected.to match(/splunkforwarder$/) } unless windows
+
+  its('content') { is_expected.to match(/\[launcher\]/) }
+  its('content') { is_expected.to match(/version = 1\.2\.0/) }
+  its('content') { is_expected.to match(/\[package\]/) }
+  its('content') { is_expected.to match(/check_for_updates = 0/) }
+  its('content') { is_expected.to match(/\[install\]/) }
+  its('content') { is_expected.to match(/is_configured = 0/) }
+  its('content') { is_expected.to match(/\[ui\]/) }
+  its('content') { is_expected.to match(/is_visible = 1/) }
+  its('content') { is_expected.to match(/label = Test App/) }
+end
+
+describe file((test_app_path + 'metadata/default.meta').to_s) do
+  it { is_expected.to be_file }
+  its('owner') { is_expected.to match(/splunkforwarder$/) } unless windows
+
+  its('content') { is_expected.to match(/\[\]/) }
+  its('content') { is_expected.to match(/access = read : \[ \* \]/) }
+
+  its('content') { is_expected.not_to match(/\[views\]/) }
+  its('content') { is_expected.not_to match(/access = read : \[ \* \], write : \[ admin, power \]/) }
+  its('content') { is_expected.not_to match(%r{\[views/index_check\]}) }
+  its('content') { is_expected.not_to match(/access = read : \[ admin \], write : \[ admin \]/) }
+end
+
+describe file((test_app_path + 'metadata/local.meta').to_s) do
+  it { is_expected.to be_file }
+  its('owner') { is_expected.to match(/splunkforwarder$/) } unless windows
+
+  its('content') { is_expected.to match(/\[views\]/) }
+  its('content') { is_expected.to match(/access = read : \[ \* \], write : \[ admin, power \]/) }
+  its('content') { is_expected.to match(%r{\[views/index_check\]}) }
+  its('content') { is_expected.to match(/access = read : \[ admin \], write : \[ admin \]/) }
+end

--- a/test/integration/uninstall/spec.rb
+++ b/test/integration/uninstall/spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 windows = os.windows?
 
 describe package(windows ? 'Splunk Enterprise' : 'splunk') do

--- a/test/integration/uninstall_forwarder/spec.rb
+++ b/test/integration/uninstall_forwarder/spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 windows = os.windows?
 
 describe package(windows ? 'UniversalForwarder' : 'splunkforwarder') do


### PR DESCRIPTION
Added a context object to the proc parameters within splunk_conf.
Also, Rubocop wanted magic spaces for magic comments. The diff is now full of hot air. Better to do it now with a simple PR.